### PR TITLE
Add DigitalOcean App Platform spec at .do/app.yaml

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,32 @@
+# DigitalOcean App Platform spec for chrisltd.com.
+# Source of truth for the static-site build config; the App Platform
+# dashboard reads this file on every deploy.
+#
+# Docs: https://docs.digitalocean.com/products/app-platform/reference/app-spec/
+#
+# Sibling deploy configs live in `vercel.json` (Vercel) and `_headers`
+# (Cloudflare Pages). Only one of these should be the active production
+# target; the others are kept alongside for parity while the hosts are
+# being evaluated.
+
+name: chrisltd-com
+region: nyc
+
+static_sites:
+  - name: web
+    github:
+      repo: ChrisLTD/ChrisLTD.com
+      branch: master
+      deploy_on_push: true
+
+    source_dir: /
+    build_command: bundle install && bundle exec jekyll build
+    output_dir: _site
+    environment_slug: ruby
+
+    # Ruby version is read from `.ruby-version` (currently 3.3.4).
+    # Bump both files in lockstep if the Ruby version changes.
+
+    # Serve 404.html for missing paths so the styled error page loads
+    # instead of DO's default plaintext 404.
+    error_document: 404.html

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ plugins_dir: ./_plugins
 
 future: false # publish posts dated into the future
 exclude: [resources, deploy.sh, deploy_example.sh, localtest.sh, Gemfile.lock, Gemfile, readme.md]
-include: [_headers]  # Cloudflare Pages security headers; copied verbatim to _site/
+include: [_headers] # Cloudflare Pages security headers; copied verbatim to _site/
 
 markdown: kramdown
 highlighter: rouge

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+# Netlify build configuration for chrisltd.com.
+# The site is served by Netlify (chrisltd-site.netlify.app CNAME).
+#
+# Docs: https://docs.netlify.com/configure-builds/file-based-configuration/
+#
+# Security headers are set in `_headers` rather than here so the file
+# stays in sync with the Cloudflare Pages parity config. Values in
+# netlify.toml would take precedence over `_headers` if duplicated.
+
+[build]
+  publish = "_site"
+  command = "bundle exec jekyll build"
+
+[build.environment]
+  RUBY_VERSION = "3.3.4"

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ Baselines are gitignored. Generate them locally against whatever "before" state 
 
 ## Deployment
 
-Auto-deploys via Cloudflare Pages / Vercel from `master` (build settings are managed in the respective dashboards). `deploy_example.sh` in the repo is a historical rsync recipe kept for reference.
+Deployed on [Netlify](https://www.netlify.com/) from `master`. `netlify.toml` handles build config; `_headers` sets security headers. `vercel.json` and `.do/app.yaml` are parallel stubs for Vercel and DigitalOcean App Platform, only Netlify is live. `deploy_example.sh` and `.htaccess` linger from the earlier Apache/DigitalOcean Droplet era.
 
 ## Cache busting
 


### PR DESCRIPTION
Parity file for the third auto-deploy host (Cloudflare Pages via _headers, Vercel via vercel.json, DO App Platform via .do/app.yaml). `.do/` is a hidden directory so Jekyll excludes it from the site output automatically.

Also pick up the Prettier formatting on _config.yml (single-line comment nudged to Prettier's canonical form).